### PR TITLE
Use HTTPS github url instead of SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-polyfill": "^6.5.0",
     "fs": "0.0.2",
     "graphql": "^0.4.18",
-    "graphql-shorthand-parser": "git+ssh://git@github.com:apollostack/graphql-shorthand-parser.git#include-dist"
+    "graphql-shorthand-parser": "https://github.com/apollostack/graphql-shorthand-parser.git#include-dist"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Avoids ssh permission errors during `npm install`. Excited to try this out!