### PR TITLE
Refactor generateSchema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,8 @@
 export {
   generateSchema,
   SchemaError,
+  addErrorLoggingToSchema,
+  addResolveFunctionsToSchema,
+  addCatchUndefinedToSchema,
+  assertResolveFunctionsPresent,
 } from './schemaGenerator';

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,5 @@
 // The primary entry point into fulfilling a GraphQL request.
 export {
   generateSchema,
-  ResolveError,
+  SchemaError,
 } from './schemaGenerator';

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -31,7 +31,7 @@ const generateSchema = (
 
   addResolveFunctionsToSchema(schema, resolveFunctions, forbidUndefinedInResolve, logger);
 
-  assertResolveFunctionPresent(schema, resolveFunctions);
+  assertResolveFunctionsPresent(schema);
 
   if (forbidUndefinedInResolve) {
     addCatchUndefinedToSchema(schema);
@@ -78,25 +78,25 @@ function addResolveFunctionsToSchema(schema, resolveFunctions) {
   });
 }
 
-function assertResolveFunctionPresent(schema, resolveFunctions) {
+function assertResolveFunctionsPresent(schema) {
   forEachField(schema, (field, typeName, fieldName) => {
     // requires a resolve function on every field that has arguments
     if (field.args.length > 0) {
-      expectResolveFunction(resolveFunctions, typeName, fieldName);
+      expectResolveFunction(field, typeName, fieldName);
     }
 
     // requires a resolve function on every field that returns a non-scalar type
     if (!(getNamedType(field.type) instanceof GraphQLScalarType)) {
-      expectResolveFunction(resolveFunctions, typeName, fieldName);
+      expectResolveFunction(field, typeName, fieldName);
     }
   });
 }
 
-function expectResolveFunction(resolveFunctions, typeName, fieldName) {
-  if (!resolveFunctions[typeName] || !resolveFunctions[typeName][fieldName]) {
+function expectResolveFunction(field, typeName, fieldName) {
+  if (!field.resolve) {
     throw new SchemaError(`Resolve function missing for "${typeName}.${fieldName}"`);
   }
-  if (typeof resolveFunctions[typeName][fieldName] !== 'function') {
+  if (typeof field.resolve !== 'function') {
     throw new SchemaError(`Resolver "${typeName}.${fieldName}" must be a function`);
   }
 }

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -149,4 +149,11 @@ function decorateToCatchUndefined(fn, hint) {
   };
 }
 
-export { generateSchema, SchemaError };
+export {
+  generateSchema,
+  SchemaError,
+  addErrorLoggingToSchema,
+  addResolveFunctionsToSchema,
+  addCatchUndefinedToSchema,
+  assertResolveFunctionsPresent,
+};

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -29,7 +29,7 @@ const generateSchema = (
   const ast = parse(schemaDefinition);
   const schema = buildASTSchema(ast);
 
-  addResolveFunctionsToSchema(schema, resolveFunctions, forbidUndefinedInResolve, logger);
+  addResolveFunctionsToSchema(schema, resolveFunctions);
 
   assertResolveFunctionsPresent(schema);
 

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -101,18 +101,16 @@ function expectResolveFunction(field, typeName, fieldName) {
 }
 
 function addErrorLoggingToSchema(schema, logger) {
+  if (!logger) {
+    throw new Error('Must provide a logger');
+  }
+  if (typeof logger.log !== 'function') {
+    throw new Error('Logger.log must be a function');
+  }
   forEachField(schema, (field, typeName, fieldName) => {
     const errorHint = `${typeName}.${fieldName}`;
     // eslint-disable-next-line no-param-reassign
     field.resolve = decorateWithLogger(field.resolve, logger, errorHint);
-  });
-}
-
-function addCatchUndefinedToSchema(schema) {
-  forEachField(schema, (field, typeName, fieldName) => {
-    const errorHint = `${typeName}.${fieldName}`;
-    // eslint-disable-next-line no-param-reassign
-    field.resolve = decorateToCatchUndefined(field.resolve, errorHint);
   });
 }
 
@@ -121,10 +119,7 @@ function addCatchUndefinedToSchema(schema) {
  * logger: an object instance of type Logger
  * hint: an optional hint to add to the error's message
  */
-function decorateWithLogger(fn, logger, hint) {
-  if (logger === null) {
-    return fn;
-  }
+function decorateWithLogger(fn, logger, hint = '') {
   return (...args) => {
     try {
       return fn(...args);
@@ -137,6 +132,14 @@ function decorateWithLogger(fn, logger, hint) {
       throw e;
     }
   };
+}
+
+function addCatchUndefinedToSchema(schema) {
+  forEachField(schema, (field, typeName, fieldName) => {
+    const errorHint = `${typeName}.${fieldName}`;
+    // eslint-disable-next-line no-param-reassign
+    field.resolve = decorateToCatchUndefined(field.resolve, errorHint);
+  });
 }
 
 function decorateToCatchUndefined(fn, hint) {

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -3,7 +3,6 @@
 import { parse } from 'graphql/language';
 import { buildASTSchema } from 'graphql/utilities';
 import { GraphQLScalarType, getNamedType } from 'graphql/type';
-import { Logger } from './Logger.js';
 
 // @schemaDefinition: A GraphQL type schema in shorthand
 // @resolvers: Definitions for resolvers to be merged with schema

--- a/test/testSchemaGenerator.js
+++ b/test/testSchemaGenerator.js
@@ -1,4 +1,4 @@
-import { generateSchema, SchemaError } from '../src/schemaGenerator.js';
+import { generateSchema, SchemaError, addErrorLoggingToSchema } from '../src/schemaGenerator.js';
 import { assert } from 'chai';
 import { graphql } from 'graphql';
 import { Logger } from '../src/Logger.js';
@@ -351,5 +351,14 @@ describe('providing useful errors from resolve functions', () => {
       assert.deepEqual(res.data, expectedResData);
       done();
     });
+  });
+});
+
+describe('Add error logging to schema', () => {
+  it('throws an error if no logger is provided', () => {
+    assert.throw(() => addErrorLoggingToSchema({}), 'Must provide a logger');
+  });
+  it('throws an error if logger.log is not a function', () => {
+    assert.throw(() => addErrorLoggingToSchema({}, { log: '1' }), 'Logger.log must be a function');
   });
 });


### PR DESCRIPTION
Breaks out a bunch of functions from generateSchema so they can be used on any GraphQL schema on their own.