### PR TITLE
Allows resolvers to be used with mocks

### DIFF
--- a/src/apolloServer.js
+++ b/src/apolloServer.js
@@ -87,6 +87,7 @@ export default function apolloServer(options, ...rest) {
         addMockFunctionsToSchema({
           schema: executableSchema,
           mocks: myMocks,
+          preserveResolvers: true,
         });
       } else {
         // this is just basics, makeExecutableSchema should catch the rest

--- a/test/testApolloServer.js
+++ b/test/testApolloServer.js
@@ -209,6 +209,40 @@ describe('ApolloServer', () => {
       return expect(res.body.data).to.deep.equal(expected);
     });
   });
+  it('can mock a schema and use partially implemented resolvers', () => {
+    const app = express();
+    const mockServer = apolloServer({
+      schema: `
+        type Query {
+          mocked: String
+          resolved(name: String): String
+        }
+        schema {
+          query: Query
+        }
+      `,
+      mocks: {
+        String: () => 'Mocked fallback',
+      },
+      resolvers: {
+        Query: {
+          resolved(root, { name }) {
+            return `Hello, ${name}!`;
+          },
+        },
+      },
+    });
+    app.use('/graphql', mockServer);
+    const expected = {
+      mocked: 'Mocked fallback',
+      resolved: 'Hello, world!',
+    };
+    return request(app).get(
+      '/graphql?query={mocked resolved(name: "world")}'
+    ).then((res) => {
+      return expect(res.body.data).to.deep.equal(expected);
+    });
+  });
   it('can mock a schema with unions', () => {
     const app = express();
     const schema = `


### PR DESCRIPTION
Previously mocks would overwrite any resolvers. Includes test. As discussed in https://github.com/apollostack/graphql-tools/issues/53.