### PR TITLE
Expose the Express response object to the options callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### vNEXT
+* `ExpressApollo` exposes the response object to the server's options callback.
+
 ### v0.2.0
 * Complete refactor of Apollo Server using TypeScript. PR [#41](https://github.com/apollostack/apollo-server/pull/41) including the following changes:
 * Dropped express-graphql dependency

--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -6,7 +6,7 @@ import ApolloOptions from './apolloOptions';
 import * as GraphiQL from '../modules/renderGraphiQL';
 
 export interface ExpressApolloOptionsFunction {
-  (req?: express.Request): ApolloOptions | Promise<ApolloOptions>;
+  (req?: express.Request, res?: express.Response): ApolloOptions | Promise<ApolloOptions>;
 }
 
 // Design principles:
@@ -32,7 +32,7 @@ export function apolloExpress(options: ApolloOptions | ExpressApolloOptionsFunct
     let optionsObject: ApolloOptions;
     if (isOptionsFunction(options)) {
       try {
-        optionsObject = await options(req);
+        optionsObject = await options(req, res);
       } catch (e) {
         res.status(500);
         res.send(`Invalid options provided to ApolloServer: ${e.message}`);


### PR DESCRIPTION
For example, it's necessary to have the response object for mutations that set/clear cookies

(note that we do already have access to the response via `req.res`, but passing it via the options callback is a bit less surprising)