### PR TITLE
Add context support to Express

### DIFF
--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -81,6 +81,7 @@ export function apolloExpress(options: ApolloOptions | ExpressApolloOptionsFunct
           schema: optionsObject.schema,
           query: query,
           variables: variables,
+          context: optionsObject.context,
           rootValue: optionsObject.rootValue,
           operationName: operationName,
           logFunction: optionsObject.logFunction,

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -21,7 +21,10 @@ const QueryType = new GraphQLObjectType({
     fields: {
         testString: {
             type: GraphQLString,
-            resolve() {
+            resolve(_, params, context) {
+                if (context) {
+                  context();
+                }
                 return 'it works';
             },
         },
@@ -271,6 +274,24 @@ export default (createApp: CreateAppFunc) => {
           return req.then((res) => {
               expect(res.status).to.equal(200);
               return expect(res.body.extensions).to.deep.equal(expected);
+          });
+      });
+
+      it('passes the context to the resolver', () => {
+          let results;
+          const expected = 'it works';
+          const app = createApp({apolloOptions: {
+              schema: Schema,
+              context: () => results = expected,
+          }});
+          const req = request(app)
+              .post('/graphql')
+              .send({
+                  query: 'query test{ testString }',
+              });
+          return req.then((res) => {
+              expect(res.status).to.equal(200);
+              return expect(results).to.equal(expected);
           });
       });
 


### PR DESCRIPTION
@helfer found this bug in the new express implementation when swapi-apollo.  I will make sure this isn't broken in HAPI