### PR TITLE
Handle multipart/form-data uploads in koaApollo

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/apollostack/apollo-proxy#readme",
   "dependencies": {
+    "async-busboy": "^0.1.1",
     "http-errors": "^1.5.0",
     "source-map-support": "^0.4.2"
   },

--- a/src/integrations/koaApollo.test.ts
+++ b/src/integrations/koaApollo.test.ts
@@ -1,6 +1,16 @@
 import * as koa from 'koa';
 import * as koaRouter from 'koa-router';
 import * as koaBody from 'koa-bodyparser';
+
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+// tslint:disable-next-line
+const request = require('supertest-as-promised');
+
 import { apolloKoa, graphiqlKoa } from './koaApollo';
 import ApolloOptions from './apolloOptions';
 import { expect } from 'chai';
@@ -29,6 +39,7 @@ function destroyApp(app) {
   app.close();
 }
 
+
 describe('koaApollo', () => {
   it('throws error if called without schema', function(){
      expect(() => apolloKoa(undefined as ApolloOptions)).to.throw('Apollo Server requires options.');
@@ -37,6 +48,67 @@ describe('koaApollo', () => {
   it('throws an error if called with more than one argument', function(){
      expect(() => (<any>apolloKoa)({}, 'x')).to.throw(
        'Apollo Server expects exactly one argument, got 2');
+  });
+  it('uploads a single file using multipart/form-data', async () => {
+    const UploadedFileType = new GraphQLObjectType({
+      name: 'UploadedFile',
+      fields: {
+        filename: { type: GraphQLString },
+        mime: { type: GraphQLString },
+      },
+    });
+
+    const TestMutationSchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'RootQuery',
+        fields: {
+          test: { type: GraphQLString },
+        },
+      }),
+      mutation: new GraphQLObjectType({
+        name: 'RootMutation',
+        fields: {
+          file: {
+            type: UploadedFileType,
+            resolve(root, data, context, wtf) {
+              return {
+                filename: root.file.filename,
+                mime: root.file.mime,
+              };
+            },
+          },
+        },
+      }),
+    });
+
+    const app = new koa();
+    const router = new koaRouter();
+    router.post('/graphql', apolloKoa({
+      schema: TestMutationSchema,
+      context: {},
+      //formatError: error => console.trace(error),
+    }));
+    app.use(router.routes());
+    app.use(router.allowedMethods());
+
+    const server = app.listen(3000);
+    const response = await request(server)
+      .post('/graphql')
+      .field('query', `mutation TestMutation {
+        file { filename, mime }
+      }`)
+      .attach('file', __filename);
+
+    server.close();
+
+    expect(JSON.parse(response.text)).to.deep.equal({
+      data: {
+        file: {
+          filename: 'koaApollo.test.js',
+          mime: 'application/javascript',
+        },
+      },
+    });
   });
 });
 


### PR DESCRIPTION
As discussed in #61, this is a quick and dirty implementation of file upload in `koaApollo` using  [`async-busboy`](https://github.com/m4nuC/async-busboy)

Basically I just modified [graphql-express](https://github.com/graphql/express-graphql/blob/master/src/__tests__/http-test.js#L676) tests.

Feedback welcome ;)

TODO:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

