### PR TITLE
Fix query batching for single queries for hapi integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Support adding parsed operations to the OperationStore. ([@nnance](https://github.com/nnance))
 * Expose ApolloOptions as part of the public API.
 
+### vNEXT
+* Fixed query batching with hapi integration. [PR #123](https://github.com/apollostack/apollo-server/pull/123)
+
 ### v0.2.5
 * Made promise compatible with fibers ([@benjamn](https://github.com/benjamn) in [#92](https://github.com/apollostack/apollo-server/pull/92))
 

--- a/src/integrations/hapiApollo.ts
+++ b/src/integrations/hapiApollo.ts
@@ -43,9 +43,9 @@ export class ApolloHAPI {
                 return;
               }
 
-              const responses = await processQuery(request.payload, optionsObject);
+              const {isBatch, responses} = await processQuery(request.payload, optionsObject);
 
-              if (responses.length > 1) {
+              if (isBatch) {
                 reply(responses);
               } else {
                 const gqlResponse = responses[0];
@@ -137,7 +137,7 @@ async function processQuery(body, optionsObject) {
       responses.push({ errors: [formatErrorFn(e)] });
     }
   }
-  return responses;
+  return {isBatch, responses};
 }
 
 function isOptionsFunction(arg: ApolloOptions | HAPIOptionsFunction): arg is HAPIOptionsFunction {

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -283,6 +283,30 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           });
       });
 
+       it('can handle batch requests', () => {
+          app = createApp();
+          const expected = [
+              {
+                  data: {
+                      testString: 'it works',
+                  },
+              },
+          ];
+          const req = request(app)
+              .post('/graphql')
+              .send([{
+                  query: `
+                      query test($echo: String){ testArgument(echo: $echo) }
+                      query test2{ testString }`,
+                  variables: { echo: 'world' },
+                  operationName: 'test2',
+              }]);
+          return req.then((res) => {
+              expect(res.status).to.equal(200);
+              return expect(res.body).to.deep.equal(expected);
+          });
+      });
+
       it('can handle a request with a mutation', () => {
           app = createApp();
           const expected = {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

The hapi integration didn't correctly check to see if a query was batched or not.

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

