### PR TITLE
Pass custom header in GraphiQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### VNEXT
+
+* Allow to pass custom headers in GraphiQL ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#133](https://github.com/apollostack/apollo-server/pull/133)).
+
 ### v0.3.0
 * Refactor Hapi integration to improve the API and make the plugins more idiomatic. ([@nnance](https://github.com/nnance)) in
 [PR #127](https://github.com/apollostack/apollo-server/pull/127)

--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -154,6 +154,7 @@ export function graphiqlExpress(options: GraphiQL.GraphiQLData) {
       query: query || options.query,
       variables: JSON.parse(variables) || options.variables,
       operationName: operationName || options.operationName,
+      passHeader: options.passHeader
     });
     res.setHeader('Content-Type', 'text/html');
     res.write(graphiQLString);

--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -154,7 +154,7 @@ export function graphiqlExpress(options: GraphiQL.GraphiQLData) {
       query: query || options.query,
       variables: JSON.parse(variables) || options.variables,
       operationName: operationName || options.operationName,
-      passHeader: options.passHeader
+      passHeader: options.passHeader,
     });
     res.setHeader('Content-Type', 'text/html');
     res.write(graphiQLString);

--- a/src/modules/renderGraphiQL.ts
+++ b/src/modules/renderGraphiQL.ts
@@ -94,7 +94,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
         otherParams[k] = parameters[k];
       }
     }
-    // We don't use safe-serialize for location, becuase it's not client input.
+    // We don't use safe-serialize for location, because it's not client input.
     var fetchURL = locationQuery(otherParams, '${endpointURL}');
     // Defines a GraphQL fetcher using the fetch API.
     function graphQLFetcher(graphQLParams) {
@@ -102,7 +102,8 @@ export function renderGraphiQL(data: GraphiQLData): string {
         method: 'post',
         headers: {
           'Accept': 'application/json',
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Authorization': localStorage['Meteor.loginToken']
         },
         body: JSON.stringify(graphQLParams),
         credentials: 'include',

--- a/src/modules/renderGraphiQL.ts
+++ b/src/modules/renderGraphiQL.ts
@@ -15,7 +15,8 @@
  * - (optional) variables: a JS object of variables to pre-fill in the GraphiQL UI
  * - (optional) operationName: the operationName to pre-fill in the GraphiQL UI
  * - (optional) result: the result of the query to pre-fill in the GraphiQL UI
- * - (optional) passHeader: a string that will be added to the header object. For example "'Authorization': localStorage['Meteor.loginToken']" for meteor
+ * - (optional) passHeader: a string that will be added to the header object.
+ * For example "'Authorization': localStorage['Meteor.loginToken']" for meteor
  */
 
 export type GraphiQLData = {
@@ -43,7 +44,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
     data.variables ? JSON.stringify(data.variables, null, 2) : null;
   const resultString = null;
   const operationName = data.operationName;
-  const passHeader = data.passHeader ? data.passHeader : ''
+  const passHeader = data.passHeader ? data.passHeader : '';
 
   /* eslint-disable max-len */
   return `

--- a/src/modules/renderGraphiQL.ts
+++ b/src/modules/renderGraphiQL.ts
@@ -15,6 +15,7 @@
  * - (optional) variables: a JS object of variables to pre-fill in the GraphiQL UI
  * - (optional) operationName: the operationName to pre-fill in the GraphiQL UI
  * - (optional) result: the result of the query to pre-fill in the GraphiQL UI
+ * - (optional) passHeader: a string that will be added to the header object. For example "'Authorization': localStorage['Meteor.loginToken']" for meteor
  */
 
 export type GraphiQLData = {
@@ -23,6 +24,7 @@ export type GraphiQLData = {
   variables?: Object,
   operationName?: string,
   result?: Object,
+  passHeader?: string
 };
 
 // Current latest version of GraphiQL.
@@ -41,6 +43,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
     data.variables ? JSON.stringify(data.variables, null, 2) : null;
   const resultString = null;
   const operationName = data.operationName;
+  const passHeader = data.passHeader ? data.passHeader : ''
 
   /* eslint-disable max-len */
   return `
@@ -103,7 +106,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-          'Authorization': localStorage['Meteor.loginToken']
+          ${passHeader}
         },
         body: JSON.stringify(graphQLParams),
         credentials: 'include',


### PR DESCRIPTION
This passes the Meteor login token in the authorization header so magically we are connected with the logged in user in GraphiQL.

-----

I wanted to make a solution that fits all types of Apps, not only Meteor. But I couldn't find a non-hacky way to pass headers to the fetch function.

So as a second option we could pass a string to renderGraphiQL (setting it in the options when creating the server) that we later put into the GraphiQL document string, like this:


```js
createApolloServer({
  /* schema and resolvers */
}, {
  graphiqlOptions: {
    passHeader: "'Authorization': localStorage['Meteor.loginToken']"
  }
})
```

```js
headers: {
  'Accept': 'application/json',
  'Content-Type': 'application/json',
  ${passHeader}
},
```

I don't like this solution very much but it works with non Meteor Apps


