### PR TITLE
Add development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,26 @@ Apollo Server and express-graphql are more or less the same thing (GraphQL middl
 Despite express-graphql being a reference implementation, Apollo Server is actually easier to understand and more modular than express-graphql.
 
 That said, Apollo Server is heavily inspired by express-graphql (it's the reference implementation after all). Rather than seeing the two as competing alternatives, we think that they both have separate roles in the GraphQL ecosystem: express-graphql is a reference implementation, and Apollo Server is a GraphQL server to be used in production and evolve quickly with the needs of the community. Over time, express-graphql can adopt those features of Apollo Server that have proven their worth and become established more widely.
+
+## Apollo Server Development
+
+If you want to develop apollo server locally you must follow the following instructions:
+
+* Install the Apollo Server project in your computer
+
+```
+git clone https://github.com/apollostack/apollo-server
+cd apollo-server
+npm install -g typescript live-server
+npm install
+npm run typings
+npm run compile
+npm link
+```
+
+* Install your local Apollo Server in other App
+
+```
+cd ~/myApp
+npm link apollo-server
+```

--- a/README.md
+++ b/README.md
@@ -171,10 +171,12 @@ That said, Apollo Server is heavily inspired by express-graphql (it's the refere
 
 If you want to develop apollo server locally you must follow the following instructions:
 
+* Fork this repository
+
 * Install the Apollo Server project in your computer
 
 ```
-git clone https://github.com/apollostack/apollo-server
+git clone https://github.com/[your-user]/apollo-server
 cd apollo-server
 npm install -g typescript live-server
 npm install


### PR DESCRIPTION
This adds instructions on how to develop for apollo-server.

**But this instructions are not complete**

I'm getting this error when doing GraphQL calls. I confirmed that it's because I have multiple instances, the schema is ok. I think the ```/src``` folder is imported too.

```
Error: Schema must be an instance of GraphQLSchema. Also ensure that there are 
not multiple versions of GraphQL installed in your node_modules directory.
```

So this PR is also a question on how to develop for this package