### PR TITLE
Pass ctx instead of ctx.request to koa options function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### VNEXT
+* Pass `ctx` instead of `ctx.request` to options function in Koa integration ([@HriBB](https://github.com/HriBB)) in [PR #154](https://github.com/apollostack/apollo-server/pull/154)
 
 ### v0.3.2
 * Added missing exports for hapi integration ([@nnance](https://github.com/nnance)) in [PR #152](https://github.com/apollostack/apollo-server/pull/152)

--- a/src/integrations/koaApollo.ts
+++ b/src/integrations/koaApollo.ts
@@ -25,7 +25,7 @@ export function apolloKoa(options: ApolloOptions | KoaApolloOptionsFunction): Ko
     let optionsObject: ApolloOptions;
     if (isOptionsFunction(options)) {
       try {
-        optionsObject = await options(ctx.request);
+        optionsObject = await options(ctx);
       } catch (e) {
         ctx.status = 500;
         return ctx.body = `Invalid options provided to ApolloServer: ${e.message}`;

--- a/src/integrations/koaApollo.ts
+++ b/src/integrations/koaApollo.ts
@@ -5,7 +5,7 @@ import ApolloOptions from './apolloOptions';
 import * as GraphiQL from '../modules/renderGraphiQL';
 
 export interface KoaApolloOptionsFunction {
-  (req: koa.Request): ApolloOptions | Promise<ApolloOptions>;
+  (ctx: koa.Context): ApolloOptions | Promise<ApolloOptions>;
 }
 
 export interface KoaHandler {


### PR DESCRIPTION
This is a breaking change. We need to mention this in the changelog.

TODO:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

