### PR TITLE
Add `apolloBatchIndex` and `apolloBatchSize` fields on the `context` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Manage TypeScript declaration files using npm. ([@od1k](https:/github.com/od1k) in [#162](https://github.com/apollostack/apollo-server/pull/162))
 * Fix connect example in readme. ([@conrad-vanl](https://github.com/conrad-vanl) in [#165](https://github.com/apollostack/apollo-server/pull/165))
 * Add try/catch to formatError. ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#174](https://github.com/apollostack/apollo-server/pull/174))
+* Add `apolloBatchIndex` and `apolloBatchSize` fields to the `context` object to let users detect when batching is requested.
 
 ### v0.3.2
 * Added missing exports for hapi integration ([@nnance](https://github.com/nnance)) in [PR #152](https://github.com/apollostack/apollo-server/pull/152)

--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -91,9 +91,12 @@ export function apolloExpress(options: ApolloOptions | ExpressApolloOptionsFunct
 
         // shallow clone the context object to put batch markers in.
         // create a context object if there isn't one passed in.
-        const context = Object.assign({}, optionsObject.context || {});
-        context.apolloBatchIndex = batchIndex;
-        context.apolloBatchSize = b.length;
+        let context = optionsObject.context;
+        if (isBatch) {
+          context = Object.assign({},  context || {});
+          context.apolloBatchIndex = batchIndex;
+          context.apolloBatchSize = b.length;
+        }
 
         let params = {
           schema: optionsObject.schema,

--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -70,11 +70,13 @@ export function apolloExpress(options: ApolloOptions | ExpressApolloOptionsFunct
     }
 
     let responses: Array<graphql.GraphQLResult> = [];
+    let batchIndex: number = -1;
     for (let requestParams of b) {
       try {
         const query = requestParams.query;
         const operationName = requestParams.operationName;
         let variables = requestParams.variables;
+        batchIndex += 1;
 
         if (typeof variables === 'string') {
           try {
@@ -87,11 +89,17 @@ export function apolloExpress(options: ApolloOptions | ExpressApolloOptionsFunct
           }
         }
 
+        // shallow clone the context object to put batch markers in.
+        // create a context object if there isn't one passed in.
+        const context = Object.assign({}, optionsObject.context || {});
+        context.apolloBatchIndex = batchIndex;
+        context.apolloBatchSize = b.length;
+
         let params = {
           schema: optionsObject.schema,
           query: query,
           variables: variables,
-          context: optionsObject.context,
+          context: context,
           rootValue: optionsObject.rootValue,
           operationName: operationName,
           logFunction: optionsObject.logFunction,

--- a/src/integrations/hapiApollo.ts
+++ b/src/integrations/hapiApollo.ts
@@ -128,14 +128,22 @@ async function processQuery(graphqlParams, optionsObject: ApolloOptions, reply) 
   const formatErrorFn = optionsObject.formatError || formatError;
 
   let responses: GraphQLResult[] = [];
+  let batchIndex: number = -1;
   for (let query of graphqlParams) {
+    batchIndex += 1;
     try {
+      // shallow clone the context object to put batch markers in.
+      // create a context object if there isn't one passed in.
+      const context = Object.assign({}, optionsObject.context || {});
+      context.apolloBatchIndex = batchIndex;
+      context.apolloBatchSize = graphqlParams.length;
+
       let params = {
         schema: optionsObject.schema,
         query: query.query,
         variables: query.variables,
         rootValue: optionsObject.rootValue,
-        context: optionsObject.context,
+        context: context,
         operationName: query.operationName,
         logFunction: optionsObject.logFunction,
         validationRules: optionsObject.validationRules,

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -5,6 +5,7 @@ import {
     GraphQLSchema,
     GraphQLObjectType,
     GraphQLString,
+    GraphQLInt,
     GraphQLError,
     introspectionQuery,
     BREAK,
@@ -44,6 +45,16 @@ const QueryType = new GraphQLObjectType({
             args: { echo: { type: GraphQLString } },
             resolve(root, { echo }) {
                 return `hello ${echo}`;
+            },
+        },
+        testBatchIndex: {
+            type: GraphQLInt,
+            resolve(root, _, context) {
+                if (context) {
+                    return context.apolloBatchIndex;
+                } else {
+                    return null;
+                }
             },
         },
         testError: {
@@ -331,6 +342,41 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
               return expect(res.body).to.deep.equal(expected);
           });
       });
+
+       it('puts batch index in context', () => {
+          app = createApp();
+          const expected = [
+              {
+                  data: {
+                      testBatchIndex: 0,
+                  },
+              },
+              {
+                  data: {
+                      testString : 'it works',
+                  },
+              },
+              {
+                  data: {
+                      testBatchIndex: 2,
+                  },
+              },
+          ];
+          const req = request(app)
+              .post('/graphql')
+              .send([{
+                  query: `query test1 { testBatchIndex }`,
+              }, {
+                  query: `query test2 { testString }`,
+              }, {
+                  query: `query test3 { testBatchIndex }`,
+              }]);
+          return req.then((res) => {
+              expect(res.status).to.equal(200);
+              return expect(res.body).to.deep.equal(expected);
+          });
+      });
+
 
       it('can handle a request with a mutation', () => {
           app = createApp();

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -389,6 +389,25 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
       });
 
 
+       it('does not put batch index in context', () => {
+          app = createApp();
+          const expected = {
+              data: {
+                  testBatchIndex: null,
+                  testBatchSize: null,
+              },
+          };
+          const req = request(app)
+              .post('/graphql')
+              .send({
+                  query: `query test1 { testBatchIndex, testBatchSize }`,
+              });
+          return req.then((res) => {
+              expect(res.status).to.equal(200);
+              return expect(res.body).to.deep.equal(expected);
+          });
+      });
+
       it('can handle a request with a mutation', () => {
           app = createApp();
           const expected = {

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -31,7 +31,7 @@ const QueryType = new GraphQLObjectType({
         testContext: {
             type: GraphQLString,
             resolve(_, args, context) {
-                return context;
+                return context.testField;
             },
         },
         testRootValue: {
@@ -419,7 +419,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           const expected = 'context works';
           app = createApp({apolloOptions: {
               schema: Schema,
-              context: expected,
+              context: {testField: expected},
           }});
           const req = request(app)
               .post('/graphql')

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -57,6 +57,16 @@ const QueryType = new GraphQLObjectType({
                 }
             },
         },
+        testBatchSize: {
+            type: GraphQLInt,
+            resolve(root, _, context) {
+                if (context) {
+                    return context.apolloBatchSize;
+                } else {
+                    return null;
+                }
+            },
+        },
         testError: {
             type: GraphQLString,
             resolve() {
@@ -349,6 +359,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
               {
                   data: {
                       testBatchIndex: 0,
+                      testBatchSize: 3,
                   },
               },
               {
@@ -365,7 +376,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           const req = request(app)
               .post('/graphql')
               .send([{
-                  query: `query test1 { testBatchIndex }`,
+                  query: `query test1 { testBatchIndex, testBatchSize }`,
               }, {
                   query: `query test2 { testString }`,
               }, {

--- a/src/integrations/koaApollo.ts
+++ b/src/integrations/koaApollo.ts
@@ -49,11 +49,13 @@ export function apolloKoa(options: ApolloOptions | KoaApolloOptionsFunction): Ko
     }
 
     let responses: Array<graphql.GraphQLResult> = [];
+    let batchIndex: number = -1;
     for (let requestParams of b) {
       try {
         const query = requestParams.query;
         const operationName = requestParams.operationName;
         let variables = requestParams.variables;
+        batchIndex += 1;
 
         if (typeof variables === 'string') {
           try {
@@ -64,11 +66,17 @@ export function apolloKoa(options: ApolloOptions | KoaApolloOptionsFunction): Ko
           }
         }
 
+        // shallow clone the context object to put batch markers in.
+        // create a context object if there isn't one passed in.
+        const context = Object.assign({}, optionsObject.context || {});
+        context.apolloBatchIndex = batchIndex;
+        context.apolloBatchSize = b.length;
+
         let params = {
           schema: optionsObject.schema,
           query: query,
           variables: variables,
-          context: optionsObject.context,
+          context: context,
           rootValue: optionsObject.rootValue,
           operationName: operationName,
           logFunction: optionsObject.logFunction,

--- a/src/integrations/koaApollo.ts
+++ b/src/integrations/koaApollo.ts
@@ -68,9 +68,12 @@ export function apolloKoa(options: ApolloOptions | KoaApolloOptionsFunction): Ko
 
         // shallow clone the context object to put batch markers in.
         // create a context object if there isn't one passed in.
-        const context = Object.assign({}, optionsObject.context || {});
-        context.apolloBatchIndex = batchIndex;
-        context.apolloBatchSize = b.length;
+        let context = optionsObject.context;
+        if (isBatch) {
+          context = Object.assign({},  context || {});
+          context.apolloBatchIndex = batchIndex;
+          context.apolloBatchSize = b.length;
+        }
 
         let params = {
           schema: optionsObject.schema,


### PR DESCRIPTION
This is so that users can detect when clients have requested batching. This will be useful for performance monitoring (see https://github.com/apollostack/optics-agent-js/issues/47)