### PR TITLE
Shallow clone the `context` object for each query in a batch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Manage TypeScript declaration files using npm. ([@od1k](https:/github.com/od1k) in [#162](https://github.com/apollostack/apollo-server/pull/162))
 * Fix connect example in readme. ([@conrad-vanl](https://github.com/conrad-vanl) in [#165](https://github.com/apollostack/apollo-server/pull/165))
 * Add try/catch to formatError. ([@nicolaslopezj](https://github.com/nicolaslopezj) in [#174](https://github.com/apollostack/apollo-server/pull/174))
+* Clone context object for each query in a batch.
 
 ### v0.3.2
 * Added missing exports for hapi integration ([@nnance](https://github.com/nnance)) in [PR #152](https://github.com/apollostack/apollo-server/pull/152)

--- a/src/integrations/expressApollo.ts
+++ b/src/integrations/expressApollo.ts
@@ -87,11 +87,19 @@ export function apolloExpress(options: ApolloOptions | ExpressApolloOptionsFunct
           }
         }
 
+        // Shallow clone context for queries in batches. This allows
+        // users to distinguish multiple queries in the batch and to
+        // modify the context object without interfering with each other.
+        let context = optionsObject.context;
+        if (isBatch) {
+          context = Object.assign({},  context || {});
+        }
+
         let params = {
           schema: optionsObject.schema,
           query: query,
           variables: variables,
-          context: optionsObject.context,
+          context: context,
           rootValue: optionsObject.rootValue,
           operationName: operationName,
           logFunction: optionsObject.logFunction,

--- a/src/integrations/integrations.test.ts
+++ b/src/integrations/integrations.test.ts
@@ -30,7 +30,11 @@ const QueryType = new GraphQLObjectType({
         testContext: {
             type: GraphQLString,
             resolve(_, args, context) {
-                return context;
+                if (context.otherField) {
+                    return 'unexpected';
+                }
+                context.otherField = true;
+                return context.testField;
             },
         },
         testRootValue: {
@@ -332,6 +336,37 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           });
       });
 
+      it('clones batch context', () => {
+          app = createApp();
+          app = createApp({apolloOptions: {
+              schema: Schema,
+              context: {testField: 'expected'},
+          }});
+          const expected = [
+              {
+                  data: {
+                      testContext: 'expected',
+                  },
+              },
+              {
+                  data: {
+                      testContext: 'expected',
+                  },
+              },
+          ];
+          const req = request(app)
+              .post('/graphql')
+              .send([{
+                  query: 'query test{ testContext }',
+              }, {
+                  query: 'query test{ testContext }',
+              }]);
+          return req.then((res) => {
+              expect(res.status).to.equal(200);
+              return expect(res.body).to.deep.equal(expected);
+          });
+      });
+
       it('can handle a request with a mutation', () => {
           app = createApp();
           const expected = {
@@ -373,7 +408,7 @@ export default (createApp: CreateAppFunc, destroyApp?: DestroyAppFunc) => {
           const expected = 'context works';
           app = createApp({apolloOptions: {
               schema: Schema,
-              context: expected,
+              context: {testField: expected},
           }});
           const req = request(app)
               .post('/graphql')

--- a/src/integrations/koaApollo.ts
+++ b/src/integrations/koaApollo.ts
@@ -64,11 +64,19 @@ export function apolloKoa(options: ApolloOptions | KoaApolloOptionsFunction): Ko
           }
         }
 
+        // Shallow clone context for queries in batches. This allows
+        // users to distinguish multiple queries in the batch and to
+        // modify the context object without interfering with each other.
+        let context = optionsObject.context;
+        if (isBatch) {
+          context = Object.assign({},  context || {});
+        }
+
         let params = {
           schema: optionsObject.schema,
           query: query,
           variables: variables,
-          context: optionsObject.context,
+          context: context,
           rootValue: optionsObject.rootValue,
           operationName: operationName,
           logFunction: optionsObject.logFunction,


### PR DESCRIPTION
This lets users distinguish multiple queries in a batch. It also
protects against users modifying the context in one query and
affecting another. (Although modifications to existing properties
of the context object will still be visible in other queries because
we only shallow copy.)

This replaced #177 